### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,22 +21,7 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: yarn
 
-      - uses: bazelbuild/setup-bazelisk@v2
-      - name: Mount bazel cache  # Optional
-        uses: actions/cache@v3
-        with:
-          path: "~/.cache/bazel"
-          key: bazel
-
-      # Functionally a linting step.
-      # Note: This may be overly brittle depending on how stable the flatc
-      # compiler is.
-      - run: bazel run //:generate_files
-
       - run: yarn install --frozen-lockfile
-
       - run: yarn run build
-      #TODO(jkuszmaul): Reenable linting.
-      #- run: yarn run lint
+      - run: yarn run lint
       - run: yarn run test
-

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "clean": "rimraf dist *.tsbuildinfo",
-    "prepack": "tsc -b tsconfig.json tsconfig.cjs.json",
+    "prepack": "yarn build",
     "build": "tsc -b tsconfig.json tsconfig.cjs.json",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "test": "jest"


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
We don't need bazel in CI since that is run manually to generate files and those files are committed to the repo.